### PR TITLE
 #20 管理画面に作成者の名前表示

### DIFF
--- a/frontend/src/pages/Management.jsx
+++ b/frontend/src/pages/Management.jsx
@@ -1,12 +1,16 @@
+import { useAuth } from "../contexts/AuthContext"
 import { Link } from "react-router-dom"
 
 // 管理画面ページ
 
 export default function Management() {
+  // AuthContextからuser情報を取得
+  const { user } = useAuth();
   return (
     <>
       <div>
         <h1>管理画面</h1>
+        <p>{user.name}さん、ようこそ！！</p>
         <Link to="/new-trip">
           <button>新規作成</button>
         </Link>


### PR DESCRIPTION
AuthContextから受け取ったuser情報を元に名前を表示

--------

分割代入を用いることで、　userオブジェクトからuserのみを取り出せる
useAuth() は、 AuthContext.Provider に渡した value オブジェクト を返す。