### PR TITLE
#32 プラン詳細ページでタイトル、日付を変更できるように

### DIFF
--- a/frontend/src/pages/Management.jsx
+++ b/frontend/src/pages/Management.jsx
@@ -48,6 +48,9 @@ export default function Management() {
                   <p>{plan.title}</p>
                   <p>{plan.start_date}</p>
                   <p>{plan.end_date}</p>
+                  <Link to={`/trip-plan/${plan.id}`}>
+                    <button>編集</button>
+                  </Link>
                 </div>
               )
             })

--- a/frontend/src/pages/NewTrip.jsx
+++ b/frontend/src/pages/NewTrip.jsx
@@ -26,13 +26,15 @@ export default function NewTrip() {
       const validatedData = schemas.tripSchema.parse(tripData);
       
       const apiData = {
-        title: validatedData.tripName,
-        start_date: validatedData.startDay,
-        end_date: validatedData.endDay,
+        title: validatedData.tripTitle,
+        start_date: validatedData.startDate,
+        end_date: validatedData.endDate,
       }
       
       const response = await api.post('/plans', apiData);
-      navigate('/trip-plan', { state: { ...response.data } });
+      
+      // プランIDのみを渡してTripPlanページに遷移
+      navigate(`/trip-plan/${response.data.id}`);
     } catch (error) {
       if (error.name === 'ZodError') {
         // Zodバリデーションエラーの場合
@@ -58,34 +60,34 @@ export default function NewTrip() {
       <div>
         <p>{error}</p>
         <div>
-          <label htmlFor="tripName">旅行タイトル</label>
+          <label htmlFor="tripTitle">旅行タイトル</label>
           <input
             type="text"
-            id="tripName"
-            name="tripName"
-            value={tripData.tripName || ''}
+            id="tripTitle"
+            name="tripTitle"
+            value={tripData.tripTitle || ''}
             placeholder="旅行タイトル"
             onChange={handleTrip}
           />
         </div>
         <div>
-          <label htmlFor="startDay">出発日</label>
+          <label htmlFor="startDate">出発日</label>
           <input
             type="date"
-            id="startDay"
-            name="startDay"
-            value={tripData.startDay || ''}
+            id="startDate"
+            name="startDate"
+            value={tripData.startDate || ''}
             placeholder="出発日"
             onChange={handleTrip}
           />
         </div>
         <div>
-          <label htmlFor="endDay">帰着日</label>
+          <label htmlFor="endDate">帰着日</label>
           <input
             type="date"
-            id="endDay"
-            name="endDay"
-            value={tripData.endDay || ''}
+            id="endDate"
+            name="endDate"
+            value={tripData.endDate || ''}
             placeholder="帰着日"
             onChange={handleTrip}
           />

--- a/frontend/src/pages/TripPlan.jsx
+++ b/frontend/src/pages/TripPlan.jsx
@@ -7,7 +7,6 @@ import { schemas } from "../validation";
 
 export default function TripPlan() {
   const { planId } = useParams(); // URLパラメータからplanIdを取得
-  // const [tripData, setTripData] = useState(null); // DBから取得したプランデータ
   const [selectedDay, setSelectedDay] = useState(1);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
@@ -49,7 +48,6 @@ export default function TripPlan() {
   const handleInputChange = e => {
     const { name, value } = e.target;
     setInputData(prev => ({ ...prev, [name]: value }));
-    console.log('inputData', inputData);
     isInputChanged.current = true;
   };
 
@@ -220,11 +218,6 @@ export default function TripPlan() {
   if (loading) {
     return <div>データを読み込み中...</div>;
   }
-
-  // // プランデータが取得できない場合
-  // if (!tripData) {
-  //   return <div>プランデータが見つかりません。</div>;
-  // }
 
   // 現在選択されている日のプランの内容を取得
   const currentDayPlan = planContents[selectedDay];

--- a/frontend/src/pages/TripPlan.jsx
+++ b/frontend/src/pages/TripPlan.jsx
@@ -1,34 +1,73 @@
 import { api } from "../api/api";
 import { useEffect, useMemo, useState } from "react";
-import { Link, useLocation } from "react-router-dom"
+import { Link, useParams } from "react-router-dom"
 import { schemas } from "../validation";
-
 
 // 旅行プラン作成ページ
 
 export default function TripPlan() {
-  const { state } = useLocation();
-  // 何日目のプランなのかを管理
+  const { planId } = useParams(); // URLパラメータからplanIdを取得
+  const [tripData, setTripData] = useState(null); // DBから取得したプランデータ
   const [selectedDay, setSelectedDay] = useState(1);
-  const [stateDate, setStateDate] = useState(state);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  // DBからプランデータを取得
+  useEffect(() => {
+    const fetchPlanData = async () => {
+      try {
+        setLoading(true);
+        const response = await api.get(`/plans/${planId}`);
+        setTripData(response.data);
+        setError('');
+      } catch (error) {
+        console.error('プランデータの取得に失敗しました:', error);
+        setError('プランデータの取得に失敗しました。');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (planId) {
+      fetchPlanData();
+    }
+  }, [planId]);
 
   // API側にデータを送信
-  const handleTripPlanUpdate = async (data) => {
+  const handleTripPlanUpdate = async (e) => {
+    const { name, value } = e.target;
+    
     try {
-      const validatedData = schemas.tripSchema.parse(data);
-      const response = await api.put(`/plans/${state.id}`, validatedData);
-      console.log(response);
+      const updatedData = {
+        titleName: name === 'tripName' ? value : tripData.title,
+        startDate: name === 'startDate' ? value : tripData.start_date,
+        endDate: name === 'endDate' ? value : tripData.end_date,
+      };
+      const validatedData = schemas.tripSchema.parse(updatedData);
+
+      const apiData = {
+        title: validatedData.tripTitle,
+        start_date: validatedData.startDate,
+        end_date: validatedData.endDate,
+      }
+
+      const response = await api.put(`/plans/${planId}`, apiData);
+      
+      // 更新に成功した場合、ローカルのstateも更新
+      setTripData(response.data);
+      setError('');
     } catch (error) {
       if (error.name === 'ZodError') {
         const allErrors = error.errors.map(error => error.message).join('\n');
         setError(allErrors);
       } else if (error.response) {
-        setError(error.response.data.message);
+        setError(error.response.data.message || 'プランの更新に失敗しました。');
         console.error('プランの更新に失敗しました。', error);
+      } else {
+        setError('ネットワークエラーが発生しました。');
       }
     }
-  }
+  };
 
   // 最初に挿入するためのプランデータ
   const initialPlanData = {time: '', content: ''};
@@ -36,8 +75,8 @@ export default function TripPlan() {
   // 旅行開始日と日数(〇日目)から、該当日付の文字列 (/MM/DD形式) を計算して返す
   const calculateDay = (selectedDay) => {
     // 旅行開始日が選択されている時のみ
-    if (stateDate.startDay){
-      const startDate = new Date(stateDate.startDay);
+    if (tripData?.start_date){
+      const startDate = new Date(tripData.start_date);
       startDate.setDate(startDate.getDate() + selectedDay - 1);
       const options = {
         month: 'numeric',
@@ -49,26 +88,26 @@ export default function TripPlan() {
 
   // 出発日と帰着日の差(ミリ秒)を計算
   const calculateDiffTime = useMemo(() => {
-    if(stateDate?.startDay && stateDate?.endDay) {
-      const startDay = new Date(stateDate.startDay);
-      const endDay = new Date(stateDate.endDay);
-      const diffTime = endDay - startDay;
+    if(tripData?.start_date && tripData?.end_date) {
+      const startDate = new Date(tripData.start_date);
+      const endDate = new Date(tripData.end_date);
+      const diffTime = endDate - startDate;
 
       return diffTime;
     }
-  }, [stateDate?.startDay, stateDate?.endDay]);
+  }, [tripData?.start_date, tripData?.end_date]);
 
   // 旅行日数を計算
   const totalDays = useMemo(() => {
     let countDay = 1;
-    if(stateDate?.startDay && stateDate?.endDay) {
+    if(tripData?.start_date && tripData?.end_date) {
       const diffTime = calculateDiffTime;
       if(diffTime >= 0) {
         countDay = Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
       }
     }
     return countDay;
-  }, [stateDate?.startDay, stateDate?.endDay, calculateDiffTime]);
+  }, [tripData?.start_date, tripData?.end_date, calculateDiffTime]);
 
   // プランデータを日付とリンク(初期設定)
   const initialPlanContents = useMemo(() => {
@@ -142,26 +181,22 @@ export default function TripPlan() {
     }));
   };
 
-  // 日付の更新
-  const handleSetDate = (e) => {
-    const { name, value } = e.target;
-
-    setStateDate(prev => {
-      const data = {...prev, [name]: value};
-
-      // API側にデータを送信
-      handleTripPlanUpdate(data);
-
-      return data;
-    });
-  }
-
   // プランデータの削除
   const handlePlanDelete = (index) => {
     setPlanContents(prev => ({
       ...prev,
       [selectedDay]: prev[selectedDay].filter((_, i) => i !== index)
     }));
+  }
+
+  // データがロード中の場合
+  if (loading) {
+    return <div>データを読み込み中...</div>;
+  }
+
+  // プランデータが取得できない場合
+  if (!tripData) {
+    return <div>プランデータが見つかりません。</div>;
   }
 
   // 現在選択されている日のプランの内容を取得
@@ -176,28 +211,40 @@ export default function TripPlan() {
             <button>管理画面へ戻る</button>
           </Link>
           <div>
-            {/* <h3>
-              <label htmlFor="tripName">旅行タイトル</label>
+            <p>{error}</p>
+            <h3>
+              <label htmlFor="tripTitle">旅行タイトル</label>
               <input
                 type="text"
-                id="tripName"
-                name="tripName"
-                value={state?.tripName || ''}
+                id="tripTitle"
+                name="tripTitle"
+                value={tripData?.title || ''}
                 placeholder="旅行タイトル"
-                onChange={handleTripPlanUpdate}/>
-                {state?.tripName}
-              </h3> */}
+                onChange={handleTripPlanUpdate}
+              />
+            </h3>
             <div>
-              <p>{error}</p>
               <span>
-                <label htmlFor="startDay">
-                  <input type="date" id="startDay" name="startDay" value={stateDate?.startDay} onChange={handleSetDate} />
+                <label htmlFor="startDate">
+                  <input
+                    type="date"
+                    id="startDate"
+                    name="startDate"
+                    value={tripData?.start_date || ''}
+                    onChange={handleTripPlanUpdate}
+                  />
                 </label>
-                </span>
+              </span>
               <span> ~ </span>
               <span>
-                <label htmlFor="endDay">
-                  <input type="date" id="endDay" name="endDay" value={stateDate?.endDay} onChange={handleSetDate} />
+                <label htmlFor="endDate">
+                  <input
+                    type="date"
+                    id="endDate"
+                    name="endDate"
+                    value={tripData?.end_date || ''}
+                    onChange={handleTripPlanUpdate}
+                  />
                 </label>
               </span>
             </div>

--- a/frontend/src/routes/routesBasic.jsx
+++ b/frontend/src/routes/routesBasic.jsx
@@ -17,7 +17,7 @@ const routesBasic = createBrowserRouter(
             <Management />
           </ProtectedRoute>
         }/>
-        <Route path="/trip-plan" element={
+        <Route path="/trip-plan/:planId" element={
           <ProtectedRoute>
             <TripPlan />
           </ProtectedRoute>

--- a/frontend/src/validation/tripSchema.jsx
+++ b/frontend/src/validation/tripSchema.jsx
@@ -1,15 +1,16 @@
 import { z } from 'zod';
 
 export const tripSchema = z.object({
-  tripName: z.string().max(255, '旅行名は255文字以内で入力してください。').nullish(),
-  startDay: z.string().date('有効な日付を入力してください。').nullish(),
-  endDay: z.string().date('有効な日付を入力してください。').nullish(),
+  tripTitle: z.string().max(255, '旅行名は255文字以内で入力してください。').nullish(),
+  startDate: z.string().date('有効な日付を入力してください。').nullish(),
+  endDate: z.string().date('有効な日付を入力してください。').nullish(),
 }).refine((data) => {
-  if (data.startDay >= data.endDay) {
+  if (data.startDate >= data.endDate) {
     return false;
   }
+  console.log('process_continue');
   return true;
 }, {
   message: '出発日は帰着日より前の日付で入力してください。',
-  path: ['endDay'],
+  path: ['endDate'],
 });


### PR DESCRIPTION
①非同期で保存処理
②DBからのデータを受け取り初期値表示
③id,name属性の名前変更
④管理画面の一覧ページに編集ボタン追加
⑤しおりごとにIDを付与

isInputChangedでフラグを用いることで、DBから値を取得するという最初の過程でuseeffectが実行されるのを防ぐ