### PR TITLE
#71 認証をLaravel Sunctum SPA認証に切り替え

### DIFF
--- a/backend/app/Http/Controllers/Auth/AuthController.php
+++ b/backend/app/Http/Controllers/Auth/AuthController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\JsonResponse;
 
@@ -14,7 +13,7 @@ class AuthController extends Controller
      * ユーザーログイン処理
      *
      * @param Request $request
-     * @return RedirectResponse
+     * @return JsonResponse
      */
     public function login(Request $request): JsonResponse
     {

--- a/backend/app/Http/Middleware/VerifyCsrfToken.php
+++ b/backend/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class VerifyCsrfToken extends Middleware
+{
+    /**
+     * The URIs that should be excluded from CSRF verification.
+     */
+    protected $except = [
+        // API routes are typically excluded as they use token authentication
+        'api/*',
+    ];
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -12,7 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->statefulApi();
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your settings for cross-origin resource sharing
+    | or "CORS". This determines what cross-origin operations may execute
+    | in web browsers. You are free to adjust these settings as needed.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    |
+    */
+
+    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+
+    'allowed_methods' => ['*'],
+
+    'allowed_origins' => ['http://localhost:5173'],
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['*'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => true,
+
+];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,20 +1,20 @@
 <?php
 
-use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\PlanController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PlanDetailController;
 
-// 認証が必要なAPIルート
-Route::middleware('auth:sanctum')->group(function () {
+// 認証が必要なAPIルート（SPA認証）
+Route::middleware(['web', 'auth:sanctum'])->group(function () {
     Route::get('/user', function(Request $request) {
         return $request->user();
     });
-    Route::post('/logout', [LoginController::class, 'logout']);
+    Route::post('/logout', [AuthController::class, 'logout']);
 
-    // プラン概要　
+    // プラン概要
     Route::apiResource('plans', PlanController::class);
 
     // プランの詳細関連
@@ -29,6 +29,8 @@ Route::middleware('auth:sanctum')->group(function () {
         ->only(['index', 'store', 'update', 'destroy']);
 });
 
-// 認証が不要なAPIルート
-Route::post('/login', [LoginController::class, 'login']);
-Route::post('/register', [RegisterController::class, 'register']);
+// 認証が不要なAPIルート（SPA認証）
+Route::middleware('web')->group(function () {
+    Route::post('/login', [AuthController::class, 'login']);
+    Route::post('/register', [RegisterController::class, 'register']);
+});

--- a/frontend/src/output.css
+++ b/frontend/src/output.css
@@ -1132,6 +1132,10 @@ body {
   right: 0px;
 }
 
+.right-2 {
+  right: 0.5rem;
+}
+
 .right-3 {
   right: 0.75rem;
 }
@@ -1148,20 +1152,16 @@ body {
   top: 0px;
 }
 
+.top-2 {
+  top: 0.5rem;
+}
+
 .top-3 {
   top: 0.75rem;
 }
 
 .top-4 {
   top: 1rem;
-}
-
-.right-2 {
-  right: 0.5rem;
-}
-
-.top-2 {
-  top: 0.5rem;
 }
 
 .z-10 {
@@ -1295,10 +1295,6 @@ body {
   aspect-ratio: 16 / 9;
 }
 
-.h-1 {
-  height: 0.25rem;
-}
-
 .h-10 {
   height: 2.5rem;
 }
@@ -1347,8 +1343,8 @@ body {
   width: 3rem;
 }
 
-.w-24 {
-  width: 6rem;
+.w-28 {
+  width: 7rem;
 }
 
 .w-4 {
@@ -1367,20 +1363,12 @@ body {
   width: 18rem;
 }
 
-.w-8 {
-  width: 2rem;
-}
-
 .w-auto {
   width: auto;
 }
 
 .w-full {
   width: 100%;
-}
-
-.w-28 {
-  width: 7rem;
 }
 
 .max-w-2xl {
@@ -1498,10 +1486,6 @@ body {
   cursor: pointer;
 }
 
-.touch-none {
-  touch-action: none;
-}
-
 .resize-none {
   resize: none;
 }
@@ -1558,12 +1542,6 @@ body {
   margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
-.space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(0.125rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(0.125rem * var(--tw-space-y-reverse));
-}
-
 .space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
@@ -1594,20 +1572,12 @@ body {
   margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
 }
 
-.self-end {
-  align-self: flex-end;
-}
-
 .overflow-hidden {
   overflow: hidden;
 }
 
 .overflow-x-auto {
   overflow-x: auto;
-}
-
-.overflow-y-auto {
-  overflow-y: auto;
 }
 
 .truncate {
@@ -1658,16 +1628,16 @@ body {
   border-bottom-width: 1px;
 }
 
+.border-accent-primary {
+  border-color: var(--color-accent-primary);
+}
+
 .border-border-primary {
   border-color: var(--color-border-primary);
 }
 
 .border-transparent {
   border-color: transparent;
-}
-
-.border-accent-primary {
-  border-color: var(--color-accent-primary);
 }
 
 .\!bg-transparent {
@@ -1696,10 +1666,6 @@ body {
 
 .bg-black\/20 {
   background-color: rgb(0 0 0 / 0.2);
-}
-
-.bg-border-secondary {
-  background-color: var(--color-border-secondary);
 }
 
 .bg-red-100 {
@@ -1891,11 +1857,6 @@ body {
 .text-xl {
   font-size: 1.25rem;
   line-height: 1.75rem;
-}
-
-.text-xs {
-  font-size: 0.75rem;
-  line-height: 1rem;
 }
 
 .font-bold {
@@ -2130,40 +2091,12 @@ body {
 }
 
 @media (min-width: 640px) {
-  .sm\:mt-2 {
-    margin-top: 0.5rem;
-  }
-
   .sm\:inline {
     display: inline;
   }
 
   .sm\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .sm\:flex-row {
-    flex-direction: row;
-  }
-
-  .sm\:items-start {
-    align-items: flex-start;
-  }
-
-  .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
-    --tw-space-x-reverse: 0;
-    margin-right: calc(0.75rem * var(--tw-space-x-reverse));
-    margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
-  }
-
-  .sm\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
-    --tw-space-y-reverse: 0;
-    margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
-    margin-bottom: calc(0px * var(--tw-space-y-reverse));
-  }
-
-  .sm\:self-start {
-    align-self: flex-start;
   }
 }
 
@@ -2174,11 +2107,6 @@ body {
 
   .md\:p-4 {
     padding: 1rem;
-  }
-
-  .md\:text-sm {
-    font-size: 0.875rem;
-    line-height: 1.25rem;
   }
 
   .md\:text-base {

--- a/frontend/src/routesBasic.jsx
+++ b/frontend/src/routesBasic.jsx
@@ -11,23 +11,34 @@ import { ProtectedRoute } from "@/components/layout/ProtectedRoute";
 export const routesBasic = createBrowserRouter(
   createRoutesFromElements(
     <>
+      {/* トップページ */}
       <Route path="/" element={<Home />} />
+
+      {/* 管理画面 */}
       <Route path="/management" element={
           <ProtectedRoute>
             <Management />
           </ProtectedRoute>
         }/>
-        <Route path="/trip-plan/:planId" element={
-          <ProtectedRoute>
-            <TripPlan />
-          </ProtectedRoute>
-        }/>
-        <Route path="/new-trip" element={
-          <ProtectedRoute>
-            <NewTripPage />
-          </ProtectedRoute>
-        }/>
+
+      {/* 旅行プラン詳細 */}
+      <Route path="/trip-plan/:planId" element={
+        <ProtectedRoute>
+          <TripPlan />
+        </ProtectedRoute>
+      }/>
+
+      {/* 新規旅行プラン作成 */}
+      <Route path="/new-trip" element={
+        <ProtectedRoute>
+          <NewTripPage />
+        </ProtectedRoute>
+      }/>
+
+      {/* ログインページ */}
       <Route path="/login" element={<Login />} />
+
+      {/* 新規登録ページ */}
       <Route path="/register" element={<Register />} />
     </>
   )

--- a/frontend/src/services/api/api.jsx
+++ b/frontend/src/services/api/api.jsx
@@ -1,8 +1,20 @@
 import axios from 'axios';
 
+// csrf用インスタンス
+const web = axios.create({
+  baseURL: import.meta.env.VITE_API_ROOT_URL,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  }
+});
+
 // API設定
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
+  withXSRFToken: true,
   headers: {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
@@ -35,4 +47,4 @@ api.interceptors.response.use(
   }
 );
 
-export { api };
+export { web, api };

--- a/frontend/src/store/AuthContext.jsx
+++ b/frontend/src/store/AuthContext.jsx
@@ -1,77 +1,62 @@
-// src/contexts/AuthContext.jsx
-import { createContext, useContext, useState, useEffect } from 'react';
-import { api } from '@/services/api/api';
+import { createContext, useContext, useState, useEffect, useMemo } from 'react';
+import { web, api } from '@/services/api/api';
 
-const AuthContext = createContext();
+const AuthContext = createContext(null);
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  // 認証状態の確認
+  // 認証状態の確認（初期マウント時）
   useEffect(() => {
     const checkAuthStatus = async () => {
-      const token = localStorage.getItem('auth_token');
-      
-      if (token) {
-        try {
-          const response = await api.get('/user');
-          setUser(response.data);
-          setIsAuthenticated(true);
-        } catch (error) {
-          console.error('認証確認エラー:', error);
-          localStorage.removeItem('auth_token');
-          setUser(null);
-          setIsAuthenticated(false);
-        }
-      } else {
+      try {
+        const { data } = await api.get('/user');
+        setUser(data);
+      } catch (error) {
         setUser(null);
-        setIsAuthenticated(false);
+        console.error('認証状態の確認エラー:', error);
+      } finally {
+        setLoading(false);
       }
-      
-      setLoading(false);
     };
-    
     checkAuthStatus();
   }, []);
 
-  // ログイン関数
+  // ログイン
   const login = async (credentials) => {
-    const response = await api.post('/login', credentials);
-    const { user, token } = response.data;
-    
-    localStorage.setItem('auth_token', token);
-    setUser(user);
-    setIsAuthenticated(true);
-    
-    return response;
+    try {
+      // CSRFクッキーを取得
+      await web.get('/sanctum/csrf-cookie');
+      // ログインリクエスト
+      const response = await api.post('/login', credentials);
+      setUser(response.data);
+    } catch (error) {
+      console.error('ログイン失敗:', error);
+      throw error;
+    }
   };
 
-  // ログアウト関数
+  // ログアウト
   const logout = async () => {
     try {
       await api.post('/logout');
     } catch (error) {
       console.error('ログアウトエラー:', error);
     } finally {
-      localStorage.removeItem('auth_token');
       setUser(null);
-      setIsAuthenticated(false);
     }
   };
 
-  return (
-    <AuthContext.Provider value={{ 
-      user, 
-      loading, 
-      isAuthenticated, 
-      login, 
-      logout 
-    }}>
-      {children}
-    </AuthContext.Provider>
-  );
+  const value = useMemo(() => ({
+    user,
+    loading,
+    isAuthenticated: !!user,
+    login,
+    logout,
+  }), [user, loading]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
 export const useAuth = () => useContext(AuthContext);


### PR DESCRIPTION
トークンベース(Sunctum API認証)ではなく、セッション・クッキーベース(Sunctum SPA認証)へ
https://readouble.com/laravel/11.x/ja/sanctum.html#spa-authentication

  - セッションデータは sessions テーブル（guide2-root/backend/database/migrations/0001_01_01_000000_create_users_table.php:30）に保存
  - クッキーに暗号化されたセッションIDが保存される


・セッションの有効期限は120分
・HttpOnly（XSS攻撃防止のため有効）→  config/session.php 'http_only' => env('SESSION_HTTP_ONLY', true),

